### PR TITLE
require json/session for multi.el7-9

### DIFF
--- a/build/fpm/src/rpm/config.multi.el7.sh
+++ b/build/fpm/src/rpm/config.multi.el7.sh
@@ -17,6 +17,8 @@ pkg_depends=(
     "libzstd"
     "lz4"
     "php$php_version_short-php(api) = $php_api-64"
+    "php$php_version_short-php-json"
+    "php$php_version_short-php-session"
     "php$php_version_short-php-msgpack"
     "php$php_version_short-php-igbinary"
 )

--- a/build/fpm/src/rpm/config.multi.el8.sh
+++ b/build/fpm/src/rpm/config.multi.el8.sh
@@ -17,6 +17,8 @@ pkg_depends=(
     "libzstd"
     "lz4"
     "php$php_version_short-php(api) = $php_api-64"
+    "php$php_version_short-php-json"
+    "php$php_version_short-php-session"
     "php$php_version_short-php-msgpack"
     "php$php_version_short-php-igbinary"
 )

--- a/build/fpm/src/rpm/config.multi.el9.sh
+++ b/build/fpm/src/rpm/config.multi.el9.sh
@@ -17,6 +17,8 @@ pkg_depends=(
     "libzstd"
     "lz4"
     "php$php_version_short-php(api) = $php_api-64"
+    "php$php_version_short-php-json"
+    "php$php_version_short-php-session"
     "php$php_version_short-php-msgpack"
     "php$php_version_short-php-igbinary"
 )


### PR DESCRIPTION
Pattern `php$php_version_short-php-*` works for `json` and `session` extensions
```shell
[root@65a7609310d3 /]# dnf provides php83-php-session
Last metadata expiration check: 0:03:13 ago on Mon Feb  3 11:33:22 2025.
php83-php-common-8.3.15-1.el9.remi.x86_64 : Common files for PHP
Repo        : remi-safe
Matched from:
Provide    : php83-php-session

php83-php-common-8.3.16-1.el9.remi.x86_64 : Common files for PHP
Repo        : remi-safe
Matched from:
Provide    : php83-php-session

[root@65a7609310d3 /]# dnf provides php83-php-json
Last metadata expiration check: 0:03:17 ago on Mon Feb  3 11:33:22 2025.
php83-php-common-8.3.15-1.el9.remi.x86_64 : Common files for PHP
Repo        : remi-safe
Matched from:
Provide    : php83-php-json = 8.3.15

php83-php-common-8.3.16-1.el9.remi.x86_64 : Common files for PHP
Repo        : remi-safe
Matched from:
Provide    : php83-php-json = 8.3.16

```