### PR TITLE
Sync sources.list with distros.sh

### DIFF
--- a/build/distros.sh
+++ b/build/distros.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Note: deb/sources.list must be kept in sync with deb_dists when this list is updated.
 deb_dists=(
   xenial   # 16.04
   bionic   # 18.04

--- a/build/distros.sh
+++ b/build/distros.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Note: deb/sources.list must be kept in sync with deb_dists when this list is updated.
+# WARNING: Keep `deb/sources.list` in sync the `deb_dists` list
 deb_dists=(
   xenial   # 16.04
   bionic   # 18.04

--- a/deb/sources.list
+++ b/deb/sources.list
@@ -3,7 +3,9 @@ deb https://repos.r2.relay.so/deb bionic main
 deb https://repos.r2.relay.so/deb focal main
 deb https://repos.r2.relay.so/deb jammy main
 deb https://repos.r2.relay.so/deb noble main
+deb https://repos.r2.relay.so/deb plucky main
 deb https://repos.r2.relay.so/deb stretch main
 deb https://repos.r2.relay.so/deb buster main
 deb https://repos.r2.relay.so/deb bullseye main
 deb https://repos.r2.relay.so/deb bookworm main
+deb https://repos.r2.relay.so/deb trixie main


### PR DESCRIPTION
## Summary

- Add `plucky` (Ubuntu 25.04) and `trixie` (Debian 13) to `deb/sources.list` to match `build/distros.sh`
- Add comment to `distros.sh` noting that `deb/sources.list` must be kept in sync when `deb_dists` is updated

https://claude.ai/code/session_01DGYjbsG4sSvx813DxjC5iG